### PR TITLE
Memory Management Arbitrary Fixes

### DIFF
--- a/gc.ts
+++ b/gc.ts
@@ -377,11 +377,11 @@ export class MarkableSwitch<P extends MarkableAllocator, F extends MarkableAlloc
   }
 }
 
-export class MarkableSegregator<N extends bigint, S extends MarkableAllocator, L extends MarkableAllocator>
+export class MarkableSegregator<S extends MarkableAllocator, L extends MarkableAllocator>
   implements MarkableAllocator {
-  allocator: H.Segregator<N, S, L>;
+  allocator: H.Segregator<S, L>;
 
-  constructor(sizeLimit: N, s: S, l: L) {
+  constructor(sizeLimit: bigint, s: S, l: L) {
     this.allocator = new H.Segregator(sizeLimit, s, l);
   }
 

--- a/heap.ts
+++ b/heap.ts
@@ -178,13 +178,13 @@ export class Switch<P extends Allocator, F extends Allocator> implements Allocat
 
 // Allocation sizes <= sizeLimit go to the small allocator
 // sizeLimit is in BYTES
-export class Segregator<N extends bigint, S extends Allocator, L extends Allocator>
+export class Segregator<S extends Allocator, L extends Allocator>
   implements Allocator {
-  sizeLimit: N;
+  sizeLimit: bigint;
   small: S;
   large: L;
 
-  constructor(sizeLimit: N, s: S, l: L) {
+  constructor(sizeLimit: bigint, s: S, l: L) {
     this.sizeLimit = sizeLimit;
     this.small = s;
     this.large = l;

--- a/heap.ts
+++ b/heap.ts
@@ -62,7 +62,7 @@ export class BumpAllocator implements MarkableAllocator {
     this.counter += size;
 
     // Ensure allocations are always aligned on an even boundary
-    if (this.counter !== 0n) {
+    if (this.counter % 2n !== 0n) {
       this.counter += 1n;
     }
 


### PR DESCRIPTION
- Update `Segregator` and `MarkableSegregator` to no longer have the size limit as a numeric constant (cannot have a nice const-generic API)
- Fix `BumpAllocator` alignment enforcement